### PR TITLE
Deploy contracts to Base Goerli

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -27,6 +27,7 @@ fs_permissions = [{ access = "read-write", path = "./deployments" }]
 [rpc_endpoints]
 mumbai = "${MUMBAI_RPC_URL}"
 polygon = "${POLYGON_RPC_URL}"
+base_goerli = "${BASE_GOERLI_RPC_URL}"
 anvil = "http://127.0.0.1:8545"
 
 [etherscan]

--- a/script/DeployVerifierLazy.s.sol
+++ b/script/DeployVerifierLazy.s.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "forge-std/Script.sol";
+import {ShowtimeVerifier} from "src/ShowtimeVerifier.sol";
+
+contract ShowtimeVerifierLocalDeployer is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        ShowtimeVerifier verifier = new ShowtimeVerifier(deployerAddress);
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
Deploying things to base goerli

Could not use the Deployer framework because the base chains are not yet in this file: https://github.com/foundry-rs/forge-std/blob/master/src/StdChains.sol#L180